### PR TITLE
Documentation: DemoModels examples in Annotated Validators was mixed up

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -34,10 +34,10 @@ class DemoModel(BaseModel):
     number: List[MyNumber]
 
 
-print(DemoModel(number=[2, 8]))
+print(DemoModel(number=[2, 4]))
 #> number=[4, 16]
 try:
-    DemoModel(number=[2, 4])
+    DemoModel(number=[2, 8])
 except ValidationError as e:
     print(e)
     """


### PR DESCRIPTION
print(DemoModel(number=[2, 8])) throws a validation error

not  DemoModel(number=[2, 4])

looks like the two examples just got mixed up

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR --> I think this is trivial?

## Change Summary

Annotated Validators documentation example was mixed up.  DemoModel(number=[2, 4]) would not throw an error, DemoModel(number=[2, 8 ]) would

## Related issue number

na

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
